### PR TITLE
Add more time options to the synchronization preferences pane

### DIFF
--- a/voipms-sms/src/main/java/net/kourlas/voipms_sms/receivers/SynchronizationIntervalReceiver.java
+++ b/voipms-sms/src/main/java/net/kourlas/voipms_sms/receivers/SynchronizationIntervalReceiver.java
@@ -26,6 +26,8 @@ import net.kourlas.voipms_sms.Database;
 import net.kourlas.voipms_sms.Preferences;
 
 public class SynchronizationIntervalReceiver extends WakefulBroadcastReceiver {
+    public static final long MILLISECONDS_PER_MINUTE = 1000L * 60L;
+
     public static void setupSynchronizationInterval(Context applicationContext) {
         Preferences preferences = Preferences.getInstance(applicationContext);
         AlarmManager alarmManager = (AlarmManager) applicationContext.getSystemService(Context.ALARM_SERVICE);
@@ -34,7 +36,7 @@ public class SynchronizationIntervalReceiver extends WakefulBroadcastReceiver {
 
         alarmManager.cancel(pendingIntent);
 
-        long syncInterval = preferences.getSyncInterval() * (24 * 60 * 60 * 1000);
+        long syncInterval = preferences.getSyncInterval() * MILLISECONDS_PER_MINUTE;
         if (syncInterval != 0) {
             long nextSyncTime = preferences.getLastCompleteSyncTime() + syncInterval;
 

--- a/voipms-sms/src/main/res/values/arrays.xml
+++ b/voipms-sms/src/main/res/values/arrays.xml
@@ -17,17 +17,24 @@
 
 <resources>
     <string-array name="preferences_sync_interval_entries">
-        <item>Every day</item>
-        <item>Every 3 days</item>
-        <item>Every 7 days</item>
-        <item>Every 30 days</item>
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>3 hours</item>
+        <item>6 hours</item>
+        <item>12 hours</item>
+        <item>1 day</item>
+        <item>7 days</item>
+        <item>30 days</item>
         <item>Never</item>
     </string-array>
     <string-array name="preferences_sync_interval_values">
-        <item>1</item>
-        <item>3</item>
-        <item>7</item>
         <item>30</item>
+        <item>60</item>
+        <item>180</item>
+        <item>720</item>
+        <item>1440</item>
+        <item>10080</item>
+        <item>43200</item>
         <item>0</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Proposal to solve #44.

I don't have any active DID's right now so can't test if everything works correctly, but it's a simple enough change to test.

The first-launch dialog also shows an empty message for some reason, but that might be because I'm using the Android Studio Beta which caused a bunch of Gradle build changes.