### PR TITLE
Only load messages you might need for the main conversations view.

### DIFF
--- a/voipms-sms/src/main/java/net/kourlas/voipms_sms/Database.java
+++ b/voipms-sms/src/main/java/net/kourlas/voipms_sms/Database.java
@@ -367,7 +367,7 @@ public class Database {
                             "from (" +
                             "   select " + COLUMN_CONTACT + ", max(" + COLUMN_DATE + ") as maxdate" +
                             "   from " + TABLE_MESSAGE +
-                            "   where did = ? " + (filterText ? " and text like ?" : "") +
+                            "   where did = ? and " + COLUMN_DELETED + " = 0 " + (filterText ? " and text like ?" : "") +
                             "   group by " + COLUMN_CONTACT +
                             ") as x inner join " + TABLE_MESSAGE + " as s on x." + COLUMN_CONTACT + " = s." + COLUMN_CONTACT + " and s." + COLUMN_DATE + " = x.maxdate"
                     ,params

--- a/voipms-sms/src/main/java/net/kourlas/voipms_sms/activities/ConversationsActivity.java
+++ b/voipms-sms/src/main/java/net/kourlas/voipms_sms/activities/ConversationsActivity.java
@@ -253,12 +253,9 @@ public class ConversationsActivity
             case R.id.mark_read_unread_button:
                 for (int i = 0; i < adapter.getItemCount(); i++) {
                     if (adapter.isItemChecked(i)) {
-                        Message[] smses = adapter.getItem(i).getMessages();
-                        for (Message message : smses) {
-                            message.setUnread(item.getTitle().equals(getResources().getString(
-                                    R.string.conversations_action_mark_unread)));
-                            database.insertMessage(message);
-                        }
+                        Conversation conversation = adapter.getItem(i);
+                        Boolean unread = item.getTitle().equals(getResources().getString(R.string.conversations_action_mark_unread));
+                        database.markConversationAsStatus(conversation.getDid(), conversation.getContact(), unread);
                     }
                 }
                 adapter.refresh();
@@ -268,11 +265,8 @@ public class ConversationsActivity
                 List<Long> databaseIds = new ArrayList<>();
                 for (int i = 0; i < adapter.getItemCount(); i++) {
                     if (adapter.isItemChecked(i)) {
-                        for (Message message : adapter.getItem(i).getMessages()) {
-                            if (message.getDatabaseId() != null) {
-                                databaseIds.add(message.getDatabaseId());
-                            }
-                        }
+                        Conversation conversation = adapter.getItem(i);
+                        databaseIds.addAll(database.getMessageDatabaseIds(conversation.getDid(), conversation.getContact()));
                     }
                 }
 

--- a/voipms-sms/src/main/java/net/kourlas/voipms_sms/adapters/ConversationsRecyclerViewAdapter.java
+++ b/voipms-sms/src/main/java/net/kourlas/voipms_sms/adapters/ConversationsRecyclerViewAdapter.java
@@ -285,8 +285,10 @@ public class ConversationsRecyclerViewAdapter
             oldFilterConstraint = filterConstraint;
             filterConstraint = constraint.toString().trim();
 
-            Conversation[] conversations = Database.getInstance(applicationContext).getConversations(
-                    preferences.getDid());
+            Conversation[] conversations = Database.getInstance(applicationContext).getLimitedFilteredConversations(
+                    preferences.getDid(),
+                    filterConstraint
+            );
             for (Conversation conversation : conversations) {
                 String contactName = Utils.getContactName(applicationContext, conversation.getContact());
 


### PR DESCRIPTION
If you have many messages and or conversations the main conversations view is pretty slow to load, especially when pressing "back" from a conversation.  This resolves that by only loading messages you might need by filtering at the DB level and only fetching the latest message therein.