### PR TITLE
Reuse or remove number regex

### DIFF
--- a/voipms-sms/src/main/java/net/kourlas/voipms_sms/model/Message.java
+++ b/voipms-sms/src/main/java/net/kourlas/voipms_sms/model/Message.java
@@ -27,6 +27,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 
 /**
  * Represents a single SMS message.
@@ -218,14 +219,8 @@ public class Message implements Comparable<Message> {
 
         this.type = Type.OUTGOING;
 
-        if (!did.replaceAll("[^0-9]", "").equals(did)) {
-            throw new IllegalArgumentException("did must consist only of numbers.");
-        }
         this.did = did;
 
-        if (!contact.replaceAll("[^0-9]", "").equals(contact)) {
-            throw new IllegalArgumentException("contact must consist only of numbers.");
-        }
         this.contact = contact;
 
         this.text = text;


### PR DESCRIPTION
This filter method was using up a lot of time on start and pushing the back button or when filtering, this cleans up the method to be easier to understand and reuses some methods like toLower() and compiles the number regex into memory for reuse and avoids doing anything when there is no filter.