### PR TITLE
Notification can stay visible until dismissed

### DIFF
--- a/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/notifications/Notifications.kt
+++ b/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/notifications/Notifications.kt
@@ -36,6 +36,7 @@ import net.kourlas.voipms_sms.demo.demo
 import net.kourlas.voipms_sms.preferences.getNotificationSound
 import net.kourlas.voipms_sms.preferences.getNotificationVibrateEnabled
 import net.kourlas.voipms_sms.preferences.getNotificationsEnabled
+import net.kourlas.voipms_sms.preferences.getNotificationUntilDismissedEnabled
 import net.kourlas.voipms_sms.sms.*
 import net.kourlas.voipms_sms.utils.applyCircularMask
 import net.kourlas.voipms_sms.utils.getContactName
@@ -129,6 +130,9 @@ class Notifications private constructor(
         }
         notification.addPerson("tel:" + contact)
         notification.setLights(0xFFAA0000.toInt(), 1000, 5000)
+        if(getNotificationUntilDismissedEnabled(context)) {
+            notification.setOngoing(true);
+        }
         val notificationSound = getNotificationSound(context)
         if (notificationSound != "") {
             notification.setSound(Uri.parse(getNotificationSound(context)))

--- a/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/preferences/preferences.kt
+++ b/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/preferences/preferences.kt
@@ -73,6 +73,16 @@ fun getNotificationVibrateEnabled(context: Context): Boolean {
             .toBoolean())
 }
 
+fun getNotificationUntilDismissedEnabled(context: Context): Boolean {
+    return getBooleanPreference(
+            context,
+            context.getString(
+                    R.string.preferences_notifications_until_dismissed_key),
+            context.getString(
+                    R.string.preferences_notifications_until_dismissed_default_value)
+                    .toBoolean())
+}
+
 fun getNotificationSound(context: Context): String {
     return getStringPreference(
         context,

--- a/voipms-sms/src/main/res/values/strings.xml
+++ b/voipms-sms/src/main/res/values/strings.xml
@@ -66,6 +66,9 @@
     <string name="preferences_notifications_vibrate_key" translatable="false">sms_notification_vibrate</string>
     <string name="preferences_notifications_vibrate_title">Vibrate</string>
     <string name="preferences_notifications_vibrate_default_value" translatable="false">true</string>
+    <string name="preferences_notifications_until_dismissed_key" translatable="false">sms_notification_until_dismissed</string>
+    <string name="preferences_notifications_until_dismissed_title">Show until dismissed</string>
+    <string name="preferences_notifications_until_dismissed_default_value" translatable="false">false</string>
 
     <!-- Network -->
     <string name="preferences_network_category_name">Network</string>

--- a/voipms-sms/src/main/res/xml/preferences.xml
+++ b/voipms-sms/src/main/res/xml/preferences.xml
@@ -51,6 +51,11 @@
             android:dependency="@string/preferences_notifications_enable_key"
             android:key="@string/preferences_notifications_vibrate_key"
             android:title="@string/preferences_notifications_vibrate_title" />
+		<net.kourlas.voipms_sms.preferences.CustomSwitchPreference
+            android:defaultValue="@string/preferences_notifications_until_dismissed_default_value"
+            android:dependency="@string/preferences_notifications_enable_key"
+            android:key="@string/preferences_notifications_until_dismissed_key"
+            android:title="@string/preferences_notifications_until_dismissed_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Synchronization">


### PR DESCRIPTION
Michael, currently notifications show up on the screen and disappear after a few seconds. I added an option for them to be shown until user's explicit dismissal. It is off by default.