### PR TITLE
Update API endpoints to remove www prefix

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -12,7 +12,7 @@
 
 ## Account
 
-This app requires access to the VoIP.ms API in order to retrieve messages from your VoIP.ms account. Go to the VoIP.ms [API Configuration menu](https://www.voip.ms/m/api.php) and:
+This app requires access to the VoIP.ms API in order to retrieve messages from your VoIP.ms account. Go to the VoIP.ms [API Configuration menu](https://voip.ms/m/api.php) and:
 * enable API access for your VoIP.ms account;
 * set an API password (which is **distinct** from your account password); and
 * set the list of approved IP addresses to "0.0.0.0".

--- a/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/RetrieveDidsWorker.kt
+++ b/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/RetrieveDidsWorker.kt
@@ -154,7 +154,7 @@ class RetrieveDidsWorker(context: Context, params: WorkerParameters) :
                 try {
                     return httpPostWithMultipartFormData(
                         applicationContext,
-                        "https://www.voip.ms/api/v1/rest.php",
+                        "https://voip.ms/api/v1/rest.php",
                         mapOf(
                             "api_username" to getEmail(applicationContext),
                             "api_password" to getPassword(applicationContext),

--- a/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/SendMessageWorker.kt
+++ b/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/SendMessageWorker.kt
@@ -284,7 +284,7 @@ class SendMessageWorker(context: Context, params: WorkerParameters) :
                 try {
                     return httpPostWithMultipartFormData(
                         applicationContext,
-                        "https://www.voip.ms/api/v1/rest.php",
+                        "https://voip.ms/api/v1/rest.php",
                         mapOf(
                             "api_username" to getEmail(applicationContext),
                             "api_password" to getPassword(applicationContext),

--- a/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/SyncWorker.kt
+++ b/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/SyncWorker.kt
@@ -457,7 +457,7 @@ class SyncWorker(context: Context, params: WorkerParameters) :
                 try {
                     return httpPostWithMultipartFormData(
                         applicationContext,
-                        "https://www.voip.ms/api/v1/rest.php",
+                        "https://voip.ms/api/v1/rest.php",
                         request.formData
                     )
                 } catch (e: IOException) {

--- a/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/VerifyCredentialsWorker.kt
+++ b/voipms-sms/src/main/kotlin/net/kourlas/voipms_sms/sms/workers/VerifyCredentialsWorker.kt
@@ -142,7 +142,7 @@ class VerifyCredentialsWorker(context: Context, params: WorkerParameters) :
                 try {
                     return httpPostWithMultipartFormData(
                         applicationContext,
-                        "https://www.voip.ms/api/v1/rest.php",
+                        "https://voip.ms/api/v1/rest.php",
                         mapOf(
                             "api_username" to email,
                             "api_password" to password,

--- a/voipms-sms/src/main/res/values/strings.xml
+++ b/voipms-sms/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
 
     <!-- SignInActivity -->
     <string name="sign_in_name">Sign in to the VoIP.ms API</string>
-    <string name="sign_in_info">&lt;strong&gt;Please read these instructions carefully.&lt;/strong&gt;&lt;br&gt;&lt;br&gt;A VoIP.ms account is required to use this app. Sign up for an account on the &lt;a href="https://www.voip.ms"&gt;VoIP.ms website&lt;/a&gt;. You must use the email address you use to log into the VoIP.ms website to log into this app.&lt;br&gt;&lt;br&gt;VoIP.ms API access is also required to use this app. Use the &lt;a href="https://www.voip.ms/m/api.php"&gt;VoIP.ms API configuration menu&lt;/a&gt; to enable API access, set an API password, and add "0.0.0.0" to the list of IP addresses approved for API access. You must use the API password to log into this app, not your normal account password.</string>
+    <string name="sign_in_info">&lt;strong&gt;Please read these instructions carefully.&lt;/strong&gt;&lt;br&gt;&lt;br&gt;A VoIP.ms account is required to use this app. Sign up for an account on the &lt;a href="https://voip.ms"&gt;VoIP.ms website&lt;/a&gt;. You must use the email address you use to log into the VoIP.ms website to log into this app.&lt;br&gt;&lt;br&gt;VoIP.ms API access is also required to use this app. Use the &lt;a href="https://voip.ms/m/api.php"&gt;VoIP.ms API configuration menu&lt;/a&gt; to enable API access, set an API password, and add "0.0.0.0" to the list of IP addresses approved for API access. You must use the API password to log into this app, not your normal account password.</string>
     <string name="sign_in_email_hint">VoIP.ms account email address</string>
     <string name="sign_in_password_hint">VoIP.ms API password</string>
     <string name="sign_in_button">Sign in</string>

--- a/voipms-sms/src/primary/kotlin/net/kourlas/voipms_sms/notifications/workers/NotificationsRegistrationWorker.kt
+++ b/voipms-sms/src/primary/kotlin/net/kourlas/voipms_sms/notifications/workers/NotificationsRegistrationWorker.kt
@@ -139,7 +139,7 @@ class NotificationsRegistrationWorker(
                 didResponses.add(
                     httpPostWithMultipartFormData(
                         applicationContext,
-                        "https://www.voip.ms/api/v1/rest.php",
+                        "https://voip.ms/api/v1/rest.php",
                         mapOf(
                             "api_username" to getEmail(applicationContext),
                             "api_password" to getPassword(applicationContext),
@@ -155,7 +155,7 @@ class NotificationsRegistrationWorker(
                 didResponses.add(
                     httpPostWithMultipartFormData(
                         applicationContext,
-                        "https://www.voip.ms/api/v1/rest.php",
+                        "https://voip.ms/api/v1/rest.php",
                         mapOf(
                             "api_username" to getEmail(applicationContext),
                             "api_password" to getPassword(applicationContext),


### PR DESCRIPTION
On or about 25/Jan/2024, voip.ms changed their server config to remove
the www prefix from their API. This broke all the clients that included
that. This updates the prefix. voip.ms denied breaking things, but it
seems it was the case after all.